### PR TITLE
Replace RCFeedEngine with FormattedRCFeed

### DIFF
--- a/includes/DiscordRCFeedEngine.php
+++ b/includes/DiscordRCFeedEngine.php
@@ -3,11 +3,11 @@
 namespace MediaWiki\Extension\DiscordRCFeed;
 
 use Exception;
+use FormattedRCFeed;
 use MediaWiki\Http\HttpRequestFactory;
 use MediaWiki\MediaWikiServices;
-use RCFeedEngine;
 
-class DiscordRCFeedEngine extends RCFeedEngine {
+class DiscordRCFeedEngine extends FormattedRCFeed {
 
 	/** @var HttpRequestFactory */
 	private $httpRequestFactory;


### PR DESCRIPTION
RCFeedEngine is a backward-compatibility alias for FormattedRCFeed since mw1.29.