### PR TITLE
Modify the title capturing regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Versions and bullets are arranged chronologically from latest to oldest.
 
+## v1.0.2
+
+- Modified the title capturing regex to fix the bug on wikis using `wiki/` as the article path. (https://github.com/femiwiki/DiscordRCFeed/issues/63)
+
 ## v1.0.1
 
 - Fixed unknown actors. (https://github.com/femiwiki/DiscordRCFeed/issues/46)

--- a/includes/HtmlToDiscordConverter.php
+++ b/includes/HtmlToDiscordConverter.php
@@ -15,7 +15,7 @@ class HtmlToDiscordConverter {
 	private const REGEX_FOR_USER_TOOLS = '#<span[^>]+class=[\'"][^\'"]*mw-usertoollinks[^\'"]*[\'"][^>]*>.+</span>#';
 
 	/** @var string */
-	private const REGEX_FOR_TITLE_LINK = '#<a[^>]+href=[\'"][^\'"=]*[/=]([^\'"]+)[\'"][^>]*title=[^>]*>([^<+]+)</a>#';
+	private const REGEX_FOR_TITLE_LINK = '#<a[^>]+href=[\'"][^\'"=]*(?:wiki/|w/|index.php/)([^\'"]+)[\'"][^>]*title=[^>]*>([^<+]+)</a>#';
 
 	/** @var string */
 	private const REGEX_FOR_GENERAL_LINK = '#<a[^>]+href=[\'"]([^\'"]+)[\'"][^>]*>([^<+]+)</a>#';

--- a/tests/phpunit/integration/HtmlToDiscordConverterTest.php
+++ b/tests/phpunit/integration/HtmlToDiscordConverterTest.php
@@ -114,20 +114,41 @@ class HtmlToDiscordConverterTest extends MediaWikiIntegrationTestCase {
 		return [
 			[
 				'[Main Page](https://foo.bar/index.php/Main_Page)',
+				'<a href="/index.php/Main_Page" title="Main Page">Main Page</a>',
+				'/index.php/$1',
+				'should replace a title link when the article path is "/index.php/$1"',
+			],
+			[
+				'[Main Page](https://foo.bar/wiki/Main_Page)',
+				'<a href="/wiki/Main_Page" title="Main Page">Main Page</a>',
+				'/wiki/$1',
+				'should replace a title link when the article path is "/wiki/$1"',
+			],
+			[
+				'[Main Page](https://foo.bar/w/Main_Page)',
 				'<a href="/w/Main_Page" title="Main Page">Main Page</a>',
-				'should replace a title link',
+				'/w/$1',
+				'should replace a title link when the article path is "/w/$1"',
 			],
 			[
 				'[Main Page](https://foo.bar/index.php/Main_Page) and [Main Page](https://foo.bar/index.php/Main_Page)',
 				'<a href="/w/Main_Page" title="Main Page">Main Page</a>'
 				. ' and <a href="/w/Main_Page" title="Main Page">Main Page</a>',
-				'should replace two title links',
+				'/index.php/$1',
+				'should replace multiple title links',
+			],
+			[
+				'[User:Admin/Test123](https://foo.bar/wiki/User:Admin/Test123)',
+				'<a href="/wiki/User:Admin/Test123" title="User:Admin/Test123">User:Admin/Test123</a>',
+				'/wiki/$1',
+				'should convert a title link with subpage when $wgArticlePath is "/wiki/$1"',
 			],
 			[
 				'[→‎Section](https://foo.bar/index.php/Main_Page#Section)',
 				'<a href="/index.php/Main_Page#Section" title="Main Page">→‎Section</a>',
-				'should convert auto comment'
-			]
+				'/index.php/$1',
+				'should convert auto comment',
+			],
 		];
 	}
 
@@ -135,10 +156,10 @@ class HtmlToDiscordConverterTest extends MediaWikiIntegrationTestCase {
 	 * @dataProvider providerTitleHtml
 	 * @covers \MediaWiki\Extension\DiscordRCFeed\HtmlToDiscordConverter::convertTitleLinks
 	 */
-	public function testConvertTitleLinks( $expected, $params, $message = '' ) {
+	public function testConvertTitleLinks( $expected, $params, $articlePath, $message = '' ) {
 		$this->setMwGlobals( [
 			'wgServer' => 'https://foo.bar',
-			'wgArticlePath' => '/index.php/$1',
+			'wgArticlePath' => $articlePath,
 			'wgScript' => '/index.php'
 		] );
 		$this->assertSame(


### PR DESCRIPTION
Modifies the title capturing regex and adds test cases for wikis using `/wiki/$1` as the article path.

Note: This is a temporary solution. We should read `$wgArticlePath` and use it to make the regular expression more general.

Issue: #63