### PR TITLE
Pass PROTO_CURRENT to getFullURL()s

### DIFF
--- a/includes/DiscordLinker.php
+++ b/includes/DiscordLinker.php
@@ -55,15 +55,15 @@ class DiscordLinker {
 			static function ( $tool ) use ( $user, $includeSelf ) {
 				if ( $tool['target'] == 'user_page' ) {
 					if ( $includeSelf ) {
-						return $user->getUserPage()->getFullURL();
+						return $user->getUserPage()->getFullURL( '', false, PROTO_CURRENT );
 					} else {
 						return null;
 					}
 				}
 				if ( $tool['target'] == 'talk' ) {
-					return $user->getTalkPage()->getFullURL();
+					return $user->getTalkPage()->getFullURL( '', false, PROTO_CURRENT );
 				}
-				return SpecialPage::getTitleFor( $tool['special'], $user->getName() )->getFullURL();
+				return SpecialPage::getTitleFor( $tool['special'], $user->getName() )->getFullURL( '', false, PROTO_CURRENT );
 			},
 			$sep
 		);
@@ -86,7 +86,7 @@ class DiscordLinker {
 					$revisionId = $revision ? $revision->getId() : null;
 					if ( $tool['target'] == 'view' ) {
 						if ( $includeSelf ) {
-							return $title->getFullURL( $revisionId ? "oldid=$revisionId" : '' );
+							return $title->getFullURL( $revisionId ? "oldid=$revisionId" : '', false, PROTO_CURRENT );
 						} else {
 							return null;
 						}
@@ -103,13 +103,13 @@ class DiscordLinker {
 							// New page, skips diff
 							return null;
 						}
-						return $title->getFullURL( "oldid=$revisionId&diff=prev" );
+						return $title->getFullURL( "oldid=$revisionId&diff=prev", false, PROTO_CURRENT );
 					}
 				}
 				if ( $title->isSpecialPage() ) {
 					return null;
 				}
-				return $title->getFullURL( $tool['query'] ?? null );
+				return $title->getFullURL( $tool['query'] ?? '', null, PROTO_CURRENT );
 			},
 			$sep
 		);
@@ -122,7 +122,7 @@ class DiscordLinker {
 	 * @return string
 	 */
 	public function makeUserTextWithTools( User $user ): string {
-		$rt = self::makeLink( $user->getUserPage()->getFullURL(), $user->getName() );
+		$rt = self::makeLink( $user->getUserPage()->getFullURL( '', false, PROTO_CURRENT ), $user->getName() );
 		if ( $this->userTools ) {
 			$tools = $this->makeUserTools( $user );
 			if ( !$tools ) {
@@ -141,7 +141,7 @@ class DiscordLinker {
 	 * @return string
 	 */
 	public function makePageTextWithTools( Title $title ): string {
-		$rt = self::makeLink( $title->getFullURL(), $title->getFullText() );
+		$rt = self::makeLink( $title->getFullURL( '', false, PROTO_CURRENT ), $title->getFullText() );
 		if ( $this->pageTools ) {
 			$tools = $this->makePageTools( $title );
 			if ( !$tools ) {

--- a/includes/DiscordLinker.php
+++ b/includes/DiscordLinker.php
@@ -63,7 +63,8 @@ class DiscordLinker {
 				if ( $tool['target'] == 'talk' ) {
 					return $user->getTalkPage()->getFullURL( '', false, PROTO_CURRENT );
 				}
-				return SpecialPage::getTitleFor( $tool['special'], $user->getName() )->getFullURL( '', false, PROTO_CURRENT );
+				return SpecialPage::getTitleFor( $tool['special'], $user->getName() )
+					->getFullURL( '', false, PROTO_CURRENT );
 			},
 			$sep
 		);
@@ -109,7 +110,7 @@ class DiscordLinker {
 				if ( $title->isSpecialPage() ) {
 					return null;
 				}
-				return $title->getFullURL( $tool['query'] ?? '', null, PROTO_CURRENT );
+				return $title->getFullURL( $tool['query'] ?? '', false, PROTO_CURRENT );
 			},
 			$sep
 		);

--- a/includes/HtmlToDiscordConverter.php
+++ b/includes/HtmlToDiscordConverter.php
@@ -91,7 +91,7 @@ class HtmlToDiscordConverter {
 				if ( !$omitTools && self::shouldIncludeTitleLinks( $title ) ) {
 					$replace = $this->linker->makePageTextWithTools( $title );
 				} else {
-					$replace = DiscordLinker::makeLink( $title->getFullURL(), $label );
+					$replace = DiscordLinker::makeLink( $title->getFullURL( '', false, PROTO_CURRENT ), $label );
 				}
 				$text = str_replace( $fullMatch, $replace, $text );
 			}


### PR DESCRIPTION
[The default](https://github.com/wikimedia/mediawiki/blob/3abca03ec052f94b62b20ee3bc0e811c84851dfd/includes/Title.php#L2180) is `PROTO_RELATIVE`.

```
 * PROTO_RELATIVE: Output a URL starting with // (protocol-relative URL)
 * PROTO_CURRENT: Output a URL starting with either http:// or https:// , depending
 *    on which protocol was used for the current incoming request
```
https://github.com/wikimedia/mediawiki/blob/3abca03ec052f94b62b20ee3bc0e811c84851dfd/includes/GlobalFunctions.php#L494-L502

#94.